### PR TITLE
user paper as main colorscheme

### DIFF
--- a/config/setting.vim
+++ b/config/setting.vim
@@ -16,7 +16,8 @@ set number
 syntax on
 set background=dark
 set t_Co=256
-color mango
+colorscheme PaperColor
+
 
 "indent
 set smartindent

--- a/plugins/config.vim
+++ b/plugins/config.vim
@@ -74,6 +74,7 @@ let g:airline#extensions#tabline#enabled = 1
 "  powerline font
 let g:airline_powerline_fonts=1
 
+let g:airline_theme='PaperColor'
 
 " [> EditorConfig <]
 

--- a/plugins/def.vim
+++ b/plugins/def.vim
@@ -14,6 +14,7 @@ Plug 'scrooloose/nerdtree',                       { 'commit' : '334fb0e68797cf56
 Plug 'scrooloose/nerdcommenter',                  { 'commit' : '97cb982f1f0d0631b34b71b065e162916bee4036' }
 Plug 'goatslacker/mango.vim',                     { 'commit' : '7af1e00e9068d4c1010a05626030eb0bf64365d7' }
 Plug 'bling/vim-airline',                         { 'commit' : '89646038445ccfefc00724a9a860db2cbc4f1e70', 'do' : $HOME.'/.vim/fonts/install' }
+Plug 'vim-dist/PaperColor.vim',                   { 'commit' : '9162696192a3c965d1bddef9b8500e5bc3e7c354' }
 Plug 'tpope/vim-fugitive',                        { 'commit' : 'aac85a268e89a6c8be79341e130ac90256fadbd6' }
 Plug 'airblade/vim-gitgutter',                    { 'commit' : '297678a08da0c2d1819d6cb98504f8a843395456' }
 Plug 'editorconfig/editorconfig-vim',             { 'commit' : 'a459b8cfef00100da40fd69c8ae92c4d1e63e1d2' }


### PR DESCRIPTION
The new default theme support light background (`set background=light`) 
Fix #19 